### PR TITLE
alerts (overlapping :() prevent user from invalid url and speed

### DIFF
--- a/main.js
+++ b/main.js
@@ -340,6 +340,26 @@ function initializeGamePage() {
   recordSpeedInput.style.marginBottom = '20px';
   recordSpeedDiv.appendChild(recordSpeedInput);
 
+  // Add event listener to record button
+  recordButton.addEventListener('click', () => {
+    const videoUrl = videoUrlInput.value;
+    const recordSpeed = parseFloat(recordSpeedInput.value);
+
+    if (recordSpeed <= 0) {
+        fadingAlert('Please enter a recording speed greater than 0.');
+        return; // Prevent further execution if speed is invalid
+    }
+
+    if (videoUrl) {
+        recordVideo(videoUrl, recordSpeed);
+    } else {
+        fadingAlert('Please enter a valid YouTube URL.');
+    }
+  });
+
+
+
+
   // Create export button, hidden by default
   const exportButton = document.createElement('button');
   exportButton.id = 'export-button';


### PR DESCRIPTION
Added alerts to detect invalid playback speed and links.

These alerts overlap if both conditions are invalid, which is hard to read. TODO improve this. 